### PR TITLE
Add github action to automatically create pdf as pre-release on commits to main

### DIFF
--- a/.github/workflows/gen_pdf.yaml
+++ b/.github/workflows/gen_pdf.yaml
@@ -1,0 +1,29 @@
+name: Generate PDF
+on:
+  push:
+    branches: [ main ]
+jobs:
+  gen-pdf:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - uses: kohlerdominik/docker-run-action@v2.0.0
+      with:
+        image: ghcr.io/biohackrxiv/bhxiv-gen-pdf:master
+        volumes: ${{ github.workspace }}:/work
+        workdir: /work
+        run: |
+          gen-pdf paper
+    - name: Create info file
+      run: |
+         echo -e "ref: $GITHUB_REF \ncommit: $GITHUB_SHA\nbuild: $(date +"%Y-%m-%dT%H:%M:%SZ")" \
+         > info.txt
+    - name: Update latest release
+      uses: pyTooling/Actions/releaser@main
+      with:
+        tag: latest
+        token: ${{ secrets.GITHUB_TOKEN }}
+        files: |
+          paper/paper.pdf
+          info.txt


### PR DESCRIPTION
See https://github.com/burgerga/publication-template/releases for result

Uses the published [biohackrxiv/bhxiv-gen-pdf](https://github.com/biohackrxiv/bhxiv-gen-pdf/pkgs/container/bhxiv-gen-pdf) docker image, added in https://github.com/biohackrxiv/bhxiv-gen-pdf/issues/39.

@egonw replaces the accidental PR I opened (https://github.com/elixir-europe/intoxicom-workshop-report-template/pull/1)