### PR TITLE
Enhance PDF workflow: PR preview, commit PDF to repo, better validation

### DIFF
--- a/.github/workflows/gen_pdf.yaml
+++ b/.github/workflows/gen_pdf.yaml
@@ -2,39 +2,88 @@ name: Generate PDF
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   gen-pdf:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-    - name: biohackathon name given?
+
+    - name: Validate metadata
       run: |
-        sed -n '/^---$/,/^---$/{//b;p}' paper/paper.md | grep biohackathon_name
-    - name: biohackathon location given?
-      run: |
-        sed -n '/^---$/,/^---$/{//b;p}' paper/paper.md | grep biohackathon_location
-    - name: biohackathon url given?
-      run: |
-        sed -n '/^---$/,/^---$/{//b;p}' paper/paper.md | grep biohackathon_url
-    - name: Git repository given?
-      run: |
-        sed -n '/^---$/,/^---$/{//b;p}' paper/paper.md | grep git_url
-    - uses: kohlerdominik/docker-run-action@v2.0.0
+        # Extract YAML front matter
+        YAML=$(sed -n '/^---$/,/^---$/{//b;p}' paper/paper.md)
+        ERRORS=""
+        for field in biohackathon_name biohackathon_location biohackathon_url git_url; do
+          if ! echo "$YAML" | grep -q "$field"; then
+            ERRORS="${ERRORS}  - Missing required field: ${field}\n"
+          fi
+        done
+        if [ -n "$ERRORS" ]; then
+          echo "::error::Metadata validation failed"
+          echo -e "The following required fields are missing from paper/paper.md:\n${ERRORS}"
+          echo "See https://index.biohackrxiv.org/for-submitters/ for details on required metadata."
+          exit 1
+        fi
+        echo "All required metadata fields present."
+
+    - name: Generate PDF
+      uses: kohlerdominik/docker-run-action@v2.0.0
       with:
         image: ghcr.io/biohackrxiv/bhxiv-gen-pdf:master
         volumes: ${{ github.workspace }}:/work
         workdir: /work
         run: |
           gen-pdf paper
+
     - name: Create info file
       run: |
          echo -e "ref: $GITHUB_REF \ncommit: $GITHUB_SHA\nbuild: $(date +"%Y-%m-%dT%H:%M:%SZ")" \
          > info.txt
+
     - name: Upload generated PDF as artifact
       uses: actions/upload-artifact@v4
       with:
-        name: PDF and info.txt
+        name: paper
         path: |
           paper/paper.pdf
           info.txt
+
+    - name: Comment on PR with PDF link
+      if: github.event_name == 'pull_request'
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+          const body = `### PDF Preview Ready\n\nThe PDF has been generated successfully. Download it from the [Actions artifacts](${runUrl}#artifacts).`;
+          // Check for existing bot comment to avoid duplicates
+          const { data: comments } = await github.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+          });
+          const botComment = comments.find(c =>
+            c.user.type === 'Bot' && c.body.includes('### PDF Preview Ready')
+          );
+          if (botComment) {
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: botComment.id,
+              body: body,
+            });
+          } else {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: body,
+            });
+          }

--- a/.github/workflows/gen_pdf.yaml
+++ b/.github/workflows/gen_pdf.yaml
@@ -6,7 +6,7 @@ on:
     branches: [ main ]
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:
@@ -55,6 +55,14 @@ jobs:
         path: |
           paper/paper.pdf
           info.txt
+
+    - name: Commit PDF to repository
+      if: github.event_name == 'push'
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git add paper/paper.pdf
+        git diff --cached --quiet && echo "No changes to PDF" || git commit -m "Update paper.pdf [skip ci]" && git push
 
     - name: Comment on PR with PDF link
       if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Summary

- **PR trigger**: Workflow now runs on `pull_request` to `main`, so authors can preview PDFs before merging
- **PR comment**: Bot automatically comments on PRs with a link to download the generated PDF from artifacts
- **Commit PDF to repo**: On push to `main`, the generated `paper.pdf` is committed back to the repository so it's always available at `paper/paper.pdf` without needing to download artifacts (uses `[skip ci]` to prevent infinite loop)
- **Better validation**: Consolidates the 4 separate `sed | grep` steps into one validation step with clear error messages listing all missing fields at once, with a link to the submitter guide
- **Artifact rename**: Changed from "PDF and info.txt" to "paper" for clarity

### Before
- Workflow only ran on push to main
- Authors had to merge first, then check Actions for the PDF
- PDF only available as an artifact that expires after 90 days
- Each missing metadata field failed separately with no helpful message

### After
| Trigger | Behaviour |
|---|---|
| Push to main | Build PDF → upload artifact → commit `paper.pdf` to repo |
| Pull request | Build PDF → upload artifact → bot comments with download link |

- All missing fields reported at once with a link to documentation
- PDF always available in the repo at `paper/paper.pdf`

## Test plan

- [ ] Open a test PR to verify the workflow triggers on PRs
- [ ] Verify the bot comment appears with the correct artifact link
- [ ] Verify push to main commits `paper.pdf` back to the repo
- [ ] Verify the `[skip ci]` prevents infinite workflow loop
- [ ] Test with missing metadata fields to verify validation error messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)